### PR TITLE
Update dependencies and artifact name for compatibility

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -31,7 +31,7 @@ module.exports = {
       name: "@rabbitholesyndrome/electron-forge-maker-portable",
       config: {
         portable: {
-          artifactName: "kafka-safe-stream-1.0.0.exe"
+          artifactName: "kafka-safe-stream-2.0.0.exe"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "app-builder-lib": "26.8.1",
     "tar": "7.5.13",
     "minimatch": "^9.0.5",
+    "@electron/asar": {
+      "minimatch": "^3.1.2"
+    },
     "@tootallnate/once": "^3.0.2",
     "http-proxy-agent": "^7.0.2",
     "tmp": "^0.2.4",


### PR DESCRIPTION
This pull request includes minor updates to the build configuration and dependencies. The changes update the artifact name for the portable build and add a nested dependency version override for `minimatch` within `@electron/asar`.

- Build configuration update:
  * Updated the `artifactName` for the portable build in `forge.config.js` to `kafka-safe-stream-2.0.0.exe`, reflecting the new version.

- Dependency management:
  * Added a nested dependency override for `minimatch` (version `^3.1.2`) within `@electron/asar` in `package.json` to ensure compatibility or address a security advisory.