### PR TITLE
Improve message consumption handling and enhance dark theme styling

### DIFF
--- a/src/backend/kafka.js
+++ b/src/backend/kafka.js
@@ -662,6 +662,9 @@ async function consumeMessages(kafka, options, onMessage, onDone) {
     let received = 0;
     const limit = (typeof maxMessages === 'number' && maxMessages > 0) ? maxMessages : null;
     let stopRequested = false;
+    const targetOffsetNumber = startMode === 'offset' && offset !== null && offset !== undefined && offset !== ''
+        ? Number(offset)
+        : null;
 
     const stopFromInside = async () => {
         if (stopRequested) return;
@@ -693,6 +696,13 @@ async function consumeMessages(kafka, options, onMessage, onDone) {
                 if (stopRequested || consumerStopping) return;
                 if (partition !== null && partition !== undefined && Number(p) !== Number(partition)) {
                     return;
+                }
+                if (targetOffsetNumber !== null && Number.isFinite(targetOffsetNumber)) {
+                    const msgOffset = Number(message.offset);
+                    if (Number.isFinite(msgOffset) && msgOffset < targetOffsetNumber) {
+                        // Ignore stale records delivered before seek fully applies.
+                        return;
+                    }
                 }
                 received += 1;
                 try {

--- a/src/backend/kafka.js
+++ b/src/backend/kafka.js
@@ -657,7 +657,12 @@ async function consumeMessages(kafka, options, onMessage, onDone) {
     }
 
     consumerStopping = false;
-    consumer = kafka.consumer({ groupId });
+    const consumerConfig = { groupId };
+    if (startMode === 'offset') {
+        // Specific-offset reads should not advance committed group offsets.
+        consumerConfig.autoCommit = false;
+    }
+    consumer = kafka.consumer(consumerConfig);
 
     let received = 0;
     const limit = (typeof maxMessages === 'number' && maxMessages > 0) ? maxMessages : null;

--- a/styles.css
+++ b/styles.css
@@ -1071,6 +1071,11 @@ body.options-resizing * {
     color: var(--color-accent);
 }
 
+body[data-theme="dark"] .consumer-messages-table .consumer-msg-value-cell {
+    color: var(--color-heading);
+    font-weight: 600;
+}
+
 .consumer-messages-table .consumer-msg-value-cell--openable {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
This pull request introduces improvements to the Kafka consumer logic and enhances the UI for message display in dark mode. The main focus is on allowing more precise control over message consumption from Kafka, especially when consuming from a specific offset, and improving message readability in the UI.

Kafka Consumer Logic Enhancements:

* The Kafka consumer is now configured to disable automatic offset commits (`autoCommit: false`) when consuming messages from a specific offset, ensuring that the committed group offsets are not advanced unintentionally.
* Added logic to skip messages with offsets lower than the specified target offset when in offset-based consumption mode, avoiding processing of stale records that may be delivered before the seek operation fully applies.

UI Improvements:

* In dark mode, the `.consumer-msg-value-cell` in the consumer messages table now uses the heading color and increased font weight for better readability.